### PR TITLE
Improve English usage

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -126,7 +126,7 @@ url: http://sapegin.me
 title: Artem Sapegin’s Home Page
 ```
 
-Examples of templates and source files [can be found here](https://github.com/sapegin/sapegin.me).
+You can find examples of templates and source files here: https://github.com/sapegin/sapegin.me.
 
 ### Multilingual blog
 
@@ -275,7 +275,7 @@ tagNames:
   tools: Tools
 ```
 
-Examples of templates and source files [can be found here](https://github.com/sapegin/blog.sapegin.me).
+You can find examples of templates and source files here: https://github.com/sapegin/blog.sapegin.me.
 
 ## Advanced Usage
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,8 +1,8 @@
-# sweet2: Batman’s toolbelt for static website generation
+# sweet2: Batman’s toolbelt for static site generation
 
 [![Build Status](https://travis-ci.org/sapegin/sweet2.svg)](https://travis-ci.org/sapegin/sweet2)
 
-Infinitely extensibe simple ES6 static website generator.
+Infinitely extensibe simple ES6 static site generator.
 
 ## Installation
 
@@ -16,7 +16,7 @@ Examples below are written in ES6, so you need Babel to run them (but Babel is n
 $ npm install --save-dev babel-cli babel-preset-es2015 babel-preset-stage-2
 ```
 
-I also recommend to use http-server to preview your website locally:
+I also recommend to use http-server to preview your site locally:
 
 ```bash
 $ npm install --save-dev http-server
@@ -72,7 +72,7 @@ And your `.babelrc` should look like this:
 
 ## Examples
 
-### Simple static website
+### Simple static site
 
 `index.js`:
 
@@ -88,7 +88,7 @@ import {
   helpers
 } from 'sweet2';
 
-start('Building the website...');
+start('Building the site...');
 
 let config = loadConfig('config');
 let options = config.base;
@@ -413,7 +413,7 @@ Add an npm script to your `package.json`:
 }
 ```
 
-Now you can use `npm run deploy` to build and upload your website to GitHub Pages.
+Now you can use `npm run deploy` to build and upload your site to GitHub Pages.
 
 ## Showcase
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,8 +1,8 @@
-# sweet2: Batman’s toolbelt for static site generation
+# sweet2: Batman’s toolbelt for static website generation
 
 [![Build Status](https://travis-ci.org/sapegin/sweet2.svg)](https://travis-ci.org/sapegin/sweet2)
 
-Infinitely extensibe simple ES6 static site generator.
+Infinitely extensibe simple ES6 static website generator.
 
 ## Installation
 
@@ -10,13 +10,13 @@ Infinitely extensibe simple ES6 static site generator.
 $ npm install --save-dev sweet2
 ```
 
-Examples below are written in ES6 so you need Babel to run them (but Babel it’s not required to use sweet2):
+Examples below are written in ES6, so you need Babel to run them (but Babel is not required to use sweet2):
 
 ```bash
 $ npm install --save-dev babel-cli babel-preset-es2015 babel-preset-stage-2
 ```
 
-I also recommend to use http-server to preview your site locally:
+I also recommend to use http-server to preview your website locally:
 
 ```bash
 $ npm install --save-dev http-server
@@ -72,7 +72,7 @@ And your `.babelrc` should look like this:
 
 ## Examples
 
-### Simple static site
+### Simple static website
 
 `index.js`:
 
@@ -88,7 +88,7 @@ import {
   helpers
 } from 'sweet2';
 
-start('Building site...');
+start('Building the website...');
 
 let config = loadConfig('config');
 let options = config.base;
@@ -126,7 +126,7 @@ url: http://sapegin.me
 title: Artem Sapegin’s Home Page
 ```
 
-Examples of templates and source files [you can find here](https://github.com/sapegin/sapegin.me).
+Examples of templates and source files [can be found here](https://github.com/sapegin/sapegin.me).
 
 ### Multilingual blog
 
@@ -152,7 +152,7 @@ import {
   helpers
 } from 'sweet2';
 
-start('Building blog...');
+start('Building the blog...');
 
 let config = loadConfig('config');
 let options = config.base;
@@ -264,7 +264,7 @@ cutTag: <!-- cut -->
 ```yaml
 url: http://blog.sapegin.me
 title: Artem Sapegin’s Blog
-description: 'Blog of a Berlin based font-end developer who works at Here, shoot photos and make something awesome on the internet.'
+description: 'Blog of a Berlin based font-end developer who works at Here, shoots photos and makes something awesome on the internet.'
 author: Artem Sapegin
 email: artem@sapegin.me
 tagNames:
@@ -275,7 +275,7 @@ tagNames:
   tools: Tools
 ```
 
-Examples of templates and source files [you can find here](https://github.com/sapegin/blog.sapegin.me).
+Examples of templates and source files [can be found here](https://github.com/sapegin/blog.sapegin.me).
 
 ## Advanced Usage
 
@@ -413,7 +413,7 @@ Add an npm script to your `package.json`:
 }
 ```
 
-Now you can use `npm run deploy` to build and upload your site to GitHub Pages.
+Now you can use `npm run deploy` to build and upload your website to GitHub Pages.
 
 ## Showcase
 


### PR DESCRIPTION
Comments regarding the changes:
- _`site` → `website`:_ in English, _website_ is used in such meaning.
- _`ES6 so` → `ES6, so`:_ [comma is required](http://www.grammarly.com/answers/questions/11235-comma-before-so/)
- _`it’s` → `is`:_ looks like a typo.
- _`site` → `the website`, `blog` → `the blog`:_ added the article.
- _`you can find here` → `can be found here`:_ the sentence should be structured as _`subject` + `verb phrase`_, i. e. _“I like her”_ instead of _“Her I like”_
- _`shoot` → `shoots`, `make` → `makes`:_ looks like a typo.

Looking forward to your comments.
